### PR TITLE
Call get() on userLocale to fix problem in injecting locale on Android

### DIFF
--- a/src/store/locale.js
+++ b/src/store/locale.js
@@ -30,7 +30,11 @@ export const getUserLocale = () => {
   let language = defaultLocale
 
   if (window.userLocale) {
-    language = window.userLocale
+    if (typeof window.userLocale.get === 'function') {
+      language = window.userLocale.get()
+    } else {
+      language = window.userLocale
+    }
   } else if (navigator.language) {
     language = navigator.language
   }


### PR DESCRIPTION
We noticed with @lorenzoprimi that it's not possible to set something in `window` to be just a string on Android, but it must be proxies via an object.