### PR TITLE
Fix UI bug in telegram and whatsapp tests

### DIFF
--- a/src/routes/Measurements/components/nettests/Telegram.js
+++ b/src/routes/Measurements/components/nettests/Telegram.js
@@ -21,7 +21,7 @@ export const TelegramDetails = ({ measurement }) => {
       measurement.test_keys.telegram_web_status === 'blocked' ||
       measurement.test_keys.telegram_http_blocking === true &&
       <div>
-        <h2 className='result-success'><i className='fa fa-check-circle-o' />
+        <h2 className='result-danger'><i className='fa fa-times-circle-o' />
           <FormattedMessage
             id='nettests.telegram.censorship'
             defaultMessage='Evidence of possible censorship'

--- a/src/routes/Measurements/components/nettests/Whatsapp.js
+++ b/src/routes/Measurements/components/nettests/Whatsapp.js
@@ -22,7 +22,7 @@ export const WhatsappDetails = ({ measurement }) => {
       measurement.test_keys.facebook_tcp_blocking === true ||
       measurement.test_keys.registration_server_status === 'blocked') &&
       <div>
-        <h2 className='result-success'><i className='fa fa-check-circle-o' />
+        <h2 className='result-danger'><i className='fa fa-times-circle-o' />
           <FormattedMessage
             id='nettests.whatsapp.censorship'
             defaultMessage='Evidence of possible censorship'


### PR DESCRIPTION
In this PR I make sure the color and the mark for "Evidence of possible censorship" is red and a cross.